### PR TITLE
Patch 1

### DIFF
--- a/src/Token.elm
+++ b/src/Token.elm
@@ -138,13 +138,14 @@ numberLiteralParser =
         ]
 
 
-stringLiteralParser : Parser String
+stringLiteralParser : Parser Token
 stringLiteralParser =
     (succeed ()
         |. chompIf ((==) '"')
         |. loop () validStringCharacter
     )
         |> getChompedString
+        |> map String
 
 
 validStringCharacter : () -> Parser (Step () ())

--- a/src/Token.elm
+++ b/src/Token.elm
@@ -65,6 +65,7 @@ loopHelper tokens =
         [ succeed (\token -> Parser.Loop (token :: tokens))
             |= oneOf
                 [ numberParser
+                , stringLiteralParser
                 , singleCharacterParser
                 , reservedWordParser
                 , identifierParser
@@ -134,6 +135,28 @@ numberLiteralParser =
           )
             |> getChompedString
             |> andThen failIfNotFloat
+        ]
+
+
+stringLiteralParser : Parser String
+stringLiteralParser =
+    (succeed ()
+        |. chompIf ((==) '"')
+        |. loop () validStringCharacter
+    )
+        |> getChompedString
+
+
+validStringCharacter : () -> Parser (Step () ())
+validStringCharacter _ =
+    oneOf
+        [ succeed (Loop ())
+            |. chompIf ((==) '\\')
+            |. chompIf ((==) '"')
+        , succeed (Loop ())
+            |. chompIf ((/=) '"')
+        , succeed (Done ())
+            |. chompIf ((==) '"')
         ]
 
 

--- a/tests/TokenTest.elm
+++ b/tests/TokenTest.elm
@@ -50,6 +50,21 @@ suite =
                     "200."
                         |> Token.scan
                         |> Expect.err
+            , test "strings require a closing double quote" <|
+                \_ ->
+                    "\"Hello"
+                        |> Token.scan
+                        |> Expect.err
+            , test "strings work without escaped quotes" <|
+                \_ ->
+                    "\"Hello\""
+                        |> Token.scan
+                        |> Expect.ok [ Token.String "\"Hello\"", Token.EOF ]
+            , test "strings work with escaped quotes" <|
+                \_ ->
+                    "\"Hello, \\\"Kelch\\\"!\""
+                        |> Token.scan
+                        |> Expect.ok [ Token.String "\"Hello, \\\"Kelch\\\"!\"", Token.EOF ]
             , test "error" <|
                 \_ ->
                     "$%$ chicket"


### PR DESCRIPTION
### description

Added in support (and some tests) for string literal parsing!

We use loop again, but this time there's no state to keep track of! We just keep chomping `\"` and non-`"` characters until we reach a `"`, and then we're done!

Combining the `|.` is how we do the equivalent of "peek" with the parser library!

#### another quick note:
The value on our string token keeps the quotes- we should figure out if we'd rather strip them out before using them in the next step!